### PR TITLE
Added Pylinter Flake8 for VS Codium

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python.linting.pylintEnabled": false,
+    "python.linting.flake8Enabled": true,
+    "python.linting.enabled": true
+}


### PR DESCRIPTION
If you guys use VS Codium, it is using automatically flake8 and warns you. Used it for the style fixes but never pushed the settings file